### PR TITLE
MNT: Remove unused info() method

### DIFF
--- a/batchpr/updater.py
+++ b/batchpr/updater.py
@@ -55,10 +55,6 @@ class Updater(metaclass=abc.ABCMeta):
         self.repo = None
         self.fork = None
 
-    def info(self, message):
-        """Print the given info message to terminal."""
-        print(message)
-
     def run(self, repositories, delay=2):
         """Open pull request, one for each of the given repositories.
 


### PR DESCRIPTION
When I saw the `info()` method, I thought I was supposed to use it. Then I found out it is unused anywhere nor mentioned in doc. So I think in the long run, it is less confusing to remove this method altogether.