### PR TITLE
Continue instead of return when process_repo fails

### DIFF
--- a/batchpr/updater.py
+++ b/batchpr/updater.py
@@ -122,7 +122,7 @@ class Updater(metaclass=abc.ABCMeta):
 
                 if not self.process_repo():
                     self.warn("    Skipping repository")
-                    return
+                    continue
 
                 self.commit_changes()
 


### PR DESCRIPTION
When `process_repo()` returns `False`, the loop should continue to the next repository, instead of returning, right? @astrofrog , please double check. Thanks.